### PR TITLE
Fix deprecated Numpy type alias

### DIFF
--- a/eqtk/solvers.py
+++ b/eqtk/solvers.py
@@ -1231,7 +1231,7 @@ def _prune_NK(N, minus_log_K, x0):
 
     prev_active = x0 > 0
     active_compounds = x0 > 0
-    active_reactions = np.zeros(n_reactions, dtype=np.bool8)
+    active_reactions = np.zeros(n_reactions, dtype=np.bool_)
     done = False
     n_reactions = N.shape[0]
 
@@ -1259,7 +1259,7 @@ def _prune_NK(N, minus_log_K, x0):
 
     # Select all compounds that are in at least one active reaction
     # Can be calc'ed as np.dot(active_reactions, N != 0), but that's not numba-able
-    active_compounds = np.empty(n_compounds, dtype=np.bool8)
+    active_compounds = np.empty(n_compounds, dtype=np.bool_)
     nonzero_N = N != 0
     nonzero_N_T = nonzero_N.transpose()
     for i in range(nonzero_N_T.shape[0]):
@@ -1296,7 +1296,7 @@ def _prune_AG(A, G, x0):
     missing species.
     """
     active_constraints = np.dot(A, x0) > 0.0
-    active_compounds = np.ones(len(x0), dtype=np.bool8)
+    active_compounds = np.ones(len(x0), dtype=np.bool_)
 
     for i, act_const in enumerate(active_constraints):
         if not act_const:

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -154,7 +154,7 @@ def test_prune_AG():
     for x0_val in [[1, 2, 3, 4, 5, 6], [1, 2, 0, 0, 0, 0], [0, 0, 0, 0, 0, 6]]:
         x0 = np.array(x0_val, dtype=float)
         A_new, G_new, x0_new, active_compounds = eqtk.solvers._prune_AG(A, G, x0)
-        assert np.array_equal(active_compounds, np.ones(6, dtype=np.bool8))
+        assert np.array_equal(active_compounds, np.ones(6, dtype=np.bool_))
         assert np.array_equal(A_new, A)
         assert np.array_equal(G_new, G)
         assert np.array_equal(x0_new, x0)
@@ -166,7 +166,7 @@ def test_prune_AG():
     G_target = np.array([2, 5], dtype=float)
     A_new, G_new, x0_new, active_compounds = eqtk.solvers._prune_AG(A, G, x0)
     assert np.array_equal(
-        active_compounds, np.array([0, 1, 0, 0, 1, 0], dtype=np.bool8)
+        active_compounds, np.array([0, 1, 0, 0, 1, 0], dtype=np.bool_)
     )
     assert np.array_equal(A_new, A_target)
     assert np.array_equal(G_new, G_target)
@@ -180,7 +180,7 @@ def test_prune_AG():
     for x0_val in [[1, 1, 1], [1, 1, 0], [0, 0, 1]]:
         x0 = np.array(x0_val, dtype=float)
         A_new, G_new, x0_new, active_compounds = eqtk.solvers._prune_AG(A, G, x0)
-        assert np.array_equal(active_compounds, np.ones(3, dtype=np.bool8))
+        assert np.array_equal(active_compounds, np.ones(3, dtype=np.bool_))
         assert np.array_equal(A_new, A)
         assert np.array_equal(G_new, G)
         assert np.array_equal(x0_new, x0)
@@ -191,7 +191,7 @@ def test_prune_AG():
     A_target = np.array([[1]], dtype=float)
     G_target = np.array([0.0])
     A_new, G_new, x0_new, active_compounds = eqtk.solvers._prune_AG(A, G, x0)
-    assert np.array_equal(active_compounds, np.array([1, 0, 0], dtype=np.bool8))
+    assert np.array_equal(active_compounds, np.array([1, 0, 0], dtype=np.bool_))
     assert np.array_equal(A_new, A_target)
     assert np.array_equal(G_new, G_target)
     assert np.array_equal(x0_new, x0_prune)
@@ -202,7 +202,7 @@ def test_prune_AG():
     A_target = np.array([[1]], dtype=float)
     G_target = np.array([0.0])
     A_new, G_new, x0_new, active_compounds = eqtk.solvers._prune_AG(A, G, x0)
-    assert np.array_equal(active_compounds, np.array([0, 1, 0], dtype=np.bool8))
+    assert np.array_equal(active_compounds, np.array([0, 1, 0], dtype=np.bool_))
     assert np.array_equal(A_new, A_target)
     assert np.array_equal(G_new, G_target)
     assert np.array_equal(x0_new, x0_prune)
@@ -218,7 +218,7 @@ def test_prune_AG():
     for x0_val in [[1, 1, 0, 0, 1], [0, 0, 0, 1, 1], [0, 1, 0, 0, 1], [1, 1, 1, 1, 1]]:
         x0 = np.array(x0_val, dtype=float)
         A_new, G_new, x0_new, active_compounds = eqtk.solvers._prune_AG(A, G, x0)
-        assert np.array_equal(active_compounds, np.ones(5, dtype=np.bool8))
+        assert np.array_equal(active_compounds, np.ones(5, dtype=np.bool_))
         assert np.array_equal(A_new, A)
         assert np.array_equal(G_new, G)
         assert np.array_equal(x0_new, x0)
@@ -229,7 +229,7 @@ def test_prune_AG():
     A_target = np.array([[1], [2]], dtype=float)
     G_target = np.array([3], dtype=float)
     A_new, G_new, x0_new, active_compounds = eqtk.solvers._prune_AG(A, G, x0)
-    assert np.array_equal(active_compounds, np.array([0, 0, 1, 0, 0], dtype=np.bool8))
+    assert np.array_equal(active_compounds, np.array([0, 0, 1, 0, 0], dtype=np.bool_))
     assert np.array_equal(A_new, A_target)
     assert np.array_equal(G_new, G_target)
     assert np.array_equal(x0_new, x0_prune)
@@ -242,7 +242,7 @@ def test_prune_AG():
         x0_prune = x0[:-1]
         A_new, G_new, x0_new, active_compounds = eqtk.solvers._prune_AG(A, G, x0)
         assert np.array_equal(
-            active_compounds, np.array([1, 1, 1, 1, 0], dtype=np.bool8)
+            active_compounds, np.array([1, 1, 1, 1, 0], dtype=np.bool_)
         )
         assert np.array_equal(A_new, A_target)
         assert np.array_equal(G_new, G_target)


### PR DESCRIPTION
`np.bool8` was [deprecated in 1.24](https://numpy.org/devdocs/release/1.24.0-notes.html#np-str0-and-similar-are-now-deprecated) and [removed in 2.0](https://numpy.org/devdocs/release/2.0.0-notes.html#numpy-2-0-python-api-removals). This PR replaces it with the equivalent `np.bool_`.

Fixes #3 